### PR TITLE
Sunsetting team plan in Docker Hub

### DIFF
--- a/deploy/k8s.yaml
+++ b/deploy/k8s.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: shokujinjp-api
-        image: shokujinjp/api:latest
+        image: ghcr.io/shokujinjp/api:latest
         ports:
         - containerPort: 8080
 ---


### PR DESCRIPTION
https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/